### PR TITLE
Fix: support systems that overload Actor.create

### DIFF
--- a/dragupload.js
+++ b/dragupload.js
@@ -293,7 +293,7 @@ async function CreateActorWithType(event, data, tokenImageData, type) {
         actorName = actorName.split(".")[0];
     }
 
-    const actor = await Actor.create(
+    const actor = await getDocumentClass("Actor").create(
     {
         name: actorName,
         type: createdType,


### PR DESCRIPTION
copied from cswendrowski/FoundryVTT-Drag-Upload#33
getDocumentClass("Actor") allows to get the actual Actor-derived class

See:
https://foundryvtt.com/api/global.html#getDocumentClass